### PR TITLE
3.5 GET /api

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,19 +1,6 @@
 const request = require("supertest");
 const app = require("../app.js");
 
-describe("GET /api", () => {
-  test("GET /api should return 200 status code", () => {
-    return request(app).get("/api").expect(200);
-  });
-  test("GET /api should return okay message", () => {
-    return request(app)
-      .get("/api")
-      .expect(200)
-      .then((res) => {
-        expect(res.body).toEqual({ message: "All Ok" });
-      });
-  });
-});
 describe("GET /api/ non-existent endpoint", () => {
   test("GET /api/{non-existent endpoint} should return 404 status code", () => {
     return request(app).get("/api/sdfjksfjl").expect(404);

--- a/__tests__/endpoints.controller.test.js
+++ b/__tests__/endpoints.controller.test.js
@@ -1,0 +1,34 @@
+const request = require("supertest");
+const app = require("../app.js");
+const connection = require("../db/connection.js");
+
+afterAll(() => {
+  return connection.end();
+});
+
+describe("GET /api", () => {
+  test("GET /api should return 200 status code", () => {
+    return request(app).get("/api/categories").expect(200);
+  });
+
+  test("GET /api should return an object", () => {
+    return request(app)
+      .get("/api")
+      .expect(200)
+      .then((response) => {
+        expect(typeof response.body).toBe('object');
+      });
+  });
+  test("GET /api should return an object the current endpoints", () => {
+    return request(app)
+      .get("/api")
+      .expect(200)
+      .then((response) => {
+        const endpointObject = response.body;
+        const endpointKeys = Object.keys(endpointObject);
+        expect(endpointKeys.length === 2).toBe(true);
+        expect(Object.hasOwn(endpointObject, 'GET /api')).toBe(true);
+        expect(Object.hasOwn(endpointObject, 'GET /api/categories')).toBe(true);
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -1,8 +1,9 @@
 const express = require("express");
 const app = express();
 const { getCategories } = require("./controllers/categories.controllers");
+const { readEndpoints } = require("./controllers/endpoints.controllers");
 
-app.get("/api", (req, res) => res.status(200).send({ message: "All Ok" }));
+app.get("/api", readEndpoints);
 
 app.get("/api/categories", getCategories);
 

--- a/controllers/endpoints.controllers.js
+++ b/controllers/endpoints.controllers.js
@@ -1,0 +1,9 @@
+const fs = require('fs').promises;
+
+exports.readEndpoints = (req, res, next) => {
+    fs.readFile(`${__dirname}/../endpoints.json`)
+    .then((returnedEndpoints) => {
+      const parsedEndpoints = JSON.parse(returnedEndpoints);
+      res.status(200).send(parsedEndpoints);
+    });
+  };

--- a/endpoints.json
+++ b/endpoints.json
@@ -13,23 +13,5 @@
         }
       ]
     }
-  },
-  "GET /api/reviews": {
-    "description": "serves an array of all reviews",
-    "queries": ["category", "sort_by", "order"],
-    "exampleResponse": {
-      "reviews": [
-        {
-          "title": "One Night Ultimate Werewolf",
-          "designer": "Akihisa Okui",
-          "owner": "happyamy2016",
-          "review_img_url": "https://images.pexels.com/photos/5350049/pexels-photo-5350049.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260",
-          "category": "hidden-roles",
-          "created_at": "2018-05-30T15:59:13.341Z",
-          "votes": 0,
-          "comment_count": 6
-        }
-      ]
-    }
   }
 }


### PR DESCRIPTION
Relevant card: https://trello.com/c/ly41SM1i

- Updated app.js -- no-longer returns with okay message when queried with just '/api'.
- Updated tests for app.js to reflect the above update.
- Introduced controller for reading local endpoint JSON file and responding with it when queried with just '/api'
- Written tests that reflect current expected return of JSON file (which will be updated as more are added).